### PR TITLE
Notifications et check passwords

### DIFF
--- a/core/core.php
+++ b/core/core.php
@@ -180,7 +180,7 @@ class core
 	 */
 	public function setNotification($notification)
 	{
-		$_SESSION['NOTIFICATION'] = $notification;
+		$_SESSION['NOTIFICATION'] .= $notification.'<br>';
 	}
 
 	/**

--- a/core/core.php
+++ b/core/core.php
@@ -527,8 +527,14 @@ class core
 	public function config()
 	{
 		if($this->getPost('submit')) {
-			if($this->getPost('password') AND $this->getPost('password') === $this->getPost('confirm')) {
-				$password = $this->getPost('password', helpers::PASSWORD);
+			if($this->getPost('password')) {
+				if($this->getPost('password') === $this->getPost('confirm')) {
+					$password = $this->getPost('password', helpers::PASSWORD);
+				}
+				else {
+					$password = $this->getData('config', 'password');
+					$this->setNotification('Mot de passe inchangé : Les mots de passe saisis sont différents.');
+				}
 			}
 			else {
 				$password = $this->getData('config', 'password');


### PR DESCRIPTION
# Nouveautés
- 2c43e7e49e3069df635b65633947f9ab85030d17
  Comparaison des champs de mots de passe lors du changement de celui-ci;
  - Affichage d'une notification s'ils ne sont pas identique.
- c8affac9e3f691bda3744d1305cda0a40b269c56
  Possibilité d'afficher plusieurs notifications;
  - Permet alors d'afficher l'erreur du mot de passe tout en affichant celle de l'enregistrement des autres paramètres.
