### PR TITLE
Corrige le layout du titre du header pour le responsive

### DIFF
--- a/core/layout.html
+++ b/core/layout.html
@@ -14,7 +14,9 @@
 <body class="<?php echo $this->getTheme(); ?>">
 <?php echo $this->panel() . $this->getNotification(); ?>
 <div id="container">
-	<h1 id="header" style="<?php echo $this->getThemeImage(); ?>"><?php echo $this->getData(['config', 'title']); ?></h1>
+	<div id="header" style="<?php echo $this->getThemeImage(); ?>">
+		<h1><?php echo $this->getData(['config', 'title']); ?></h1>
+	</div>
 	<div id="toggle"><span></span></div>
 	<ul id="menu"><?php echo $this->menu(); ?></ul>
 	<div id="section">

--- a/core/theme.css
+++ b/core/theme.css
@@ -93,14 +93,24 @@ body {
 
 /* Haut de page */
 #header {
+	width: 100%;
 	height: 160px;
-	line-height: 160px;
-	margin: 0;
-	text-align: center;
-	font-size: 1.8em;
-	color: #FFF;
+	margin: 0 auto;
 	background-position: center;
 	background-repeat: no-repeat;
+}
+#header h1 {
+	margin: 0;
+	position: relative;
+	top: 50%;
+	text-align: center;
+	color: #FFF;
+	font-size: 1.8em;
+	-webkit-transform: translateY(-50%);
+	-moz-transform: translateY(-50%);
+	-ms-transform: translateY(-50%);
+	transform: translateY(-50%);
+
 }
 
 /* Menu */
@@ -675,7 +685,7 @@ th.offset11 {
 }
 
 /* Cache le titre de la bannière après l'ajout d'une image */
-.themeImage #header {
+.themeImage #header h1 {
 	font-size: 0;
 }
 
@@ -1736,5 +1746,7 @@ th.offset11 {
 /* Couleur normale */
 .themeHeaderWhite #header {
 	background-color: #FFFFFF;
+}
+.themeHeaderWhite #header h1 {
 	color: #2C3E50;
 }


### PR DESCRIPTION
Issue #70 

Le titre n'est plus coupé et passe à la ligne.

![image](https://cloud.githubusercontent.com/assets/3357171/12922390/8e80495e-cf51-11e5-9850-1045e87d6490.png)
