### PR TITLE
Fix module news traduction en_EN

### DIFF
--- a/modules/news/langs/en_EN.json
+++ b/modules/news/langs/en_EN.json
@@ -4,10 +4,10 @@
 	"Modifier" : "Edit",
 	"Êtes-vous sûr de vouloir supprimer cette news ?" : "Are you sure you want to delete this news?",
 	"Nouvelle news" : "New news",
-	"Titre de la news" : "News title",
-	"Créer" : "Create",
 	"Liste des news" : "News list",
 	"Retour" : "Return",
+	"Titre de la news" : "News title",
+	"Créer" : "Create",
 	"News modifiée avec succès !" : "News successfully edited!",
 	"News supprimée avec succès !" : "News successfully deleted!"
 }

--- a/modules/news/langs/en_EN.json
+++ b/modules/news/langs/en_EN.json
@@ -2,7 +2,6 @@
 	"Gestionnaire de news" : "News manager",
 	"Nouvelle news créée avec succès !" : "New news successfully created!",
 	"Modifier" : "Edit",
-	"Supprimer" : "Remove",
 	"Êtes-vous sûr de vouloir supprimer cette news ?" : "Are you sure you want to delete this news?",
 	"Nouvelle news" : "New news",
 	"Titre de la news" : "News title",

--- a/modules/news/langs/en_EN.json
+++ b/modules/news/langs/en_EN.json
@@ -5,6 +5,7 @@
 	"Êtes-vous sûr de vouloir supprimer cette news ?" : "Are you sure you want to delete this news?",
 	"Nouvelle news" : "New news",
 	"Liste des news" : "News list",
+	"Aucune news...": "No news",
 	"Retour" : "Return",
 	"Titre de la news" : "News title",
 	"Créer" : "Create",


### PR DESCRIPTION
Traduction du module news en_EN mise à jour :
- Suppression d'un doublons ;
- Réorganisation des chaines dans l'ordre ou elles sont utilisées dans le fichier news ;
- Ajout d'une chaine manquante.
